### PR TITLE
added override for webcam

### DIFF
--- a/css/_hide_webcam_override.scss
+++ b/css/_hide_webcam_override.scss
@@ -1,0 +1,3 @@
+.videocontainer.display-avatar-with-name {
+    display: none !important;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -104,5 +104,6 @@ $flagsImagePath: "../images/";
 @import 'plan-limit';
 @import 'polls';
 @import 'notifications';
+@import 'hide_webcam_override';
 
 /* Modules END */


### PR DESCRIPTION
> An override to hide a webcam tile when the webcam is off

## Presence in minified css
<img width="758" alt="image" src="https://user-images.githubusercontent.com/127187/146194346-2aa59dce-b6a9-4a46-8749-69f52ed1ded9.png">

## Webcam off
<img width="831" alt="image" src="https://user-images.githubusercontent.com/127187/146193904-1c1d2abd-bdbd-4bcf-8d54-9ec8fa838fee.png">

## Webcam on
<img width="892" alt="image" src="https://user-images.githubusercontent.com/127187/146194026-4f97859d-3755-4ec5-8392-474bcf6cca8b.png">
